### PR TITLE
Fix for mapMarkerServer.sqf script error

### DIFF
--- a/template/functions/system/fn_mapMarkersServer.sqf
+++ b/template/functions/system/fn_mapMarkersServer.sqf
@@ -55,8 +55,8 @@ if (!isNil "XPT_mapMarkersList") exitWith {
 			// Define more variables
 			private ["_x", "_grpMarker", "_markerPrefix", "_markerSuffix", "_markerType"];
 			// Check if the group has a marker already
-			_grpMarker = _x getVariable ["XPT_mapMarker", nil];
-			if ((getMarkerType _grpMarker) == "") then (_grpMarker = nil);
+			_grpMarker = _x getVariable ["XPT_mapMarker", ""];
+			if ((getMarkerType _grpMarker) == "") then {_grpMarker = nil};
 			if (isNil "_grpMarker") then {
 				// If the group does not yet have a marker, create one
 				_grpMarker = createMarker [format ["xpt_mapMarker_%1", _x], getPosATL (leader _x)];


### PR DESCRIPTION
Unsure about changing `nil` to `""` in [line 58](https://github.com/blah2355/tmtm_template/blob/fd602472409263b91ad31f145b6e5b2f154e1318/template/functions/system/fn_mapMarkersServer.sqf#L58) but the next line gave errors because `_grpMarker` was defaulted to nil and did not exist.