### PR TITLE
Inventory system: Add optional custom loadout function injection

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -33,7 +33,7 @@ class Header
 //#define XPT_DEBUGMODE 0							// 0 = Disabled, 1 = Enabled.
 
 //#define XPT_DEFINE_CUSTOMLOADOUTS 1				                     // 0 = Disabled, 1 = Enabled. Enables the loadout system
-//#define XPT_CUSTOMLOADOUTS_GETLOADOUTARRAY_FN TAG_fnc_getLoadoutArray  // Custom loadout resolution function to use in the loadout system. REQUIRES MISSION SUPPORT.
+//#define XPT_CUSTOMLOADOUTS_LOADOUTOVERRIDE_FN TAG_fnc_getLoadoutArray  // Custom loadout resolution function to use in the loadout system. REQUIRES MISSION SUPPORT.
 
 // Curator settings
 //#define XPT_DEFINE_CURATOR_CUSTOMLOADOUTS 1		// 0 = Disabled, 1 = Enabled.

--- a/description.ext
+++ b/description.ext
@@ -32,7 +32,8 @@ class Header
 
 //#define XPT_DEBUGMODE 0							// 0 = Disabled, 1 = Enabled.
 
-//#define XPT_DEFINE_CUSTOMLOADOUTS 1				// 0 = Disabled, 1 = Enabled. Enables the loadout system
+//#define XPT_DEFINE_CUSTOMLOADOUTS 1				                     // 0 = Disabled, 1 = Enabled. Enables the loadout system
+//#define XPT_CUSTOMLOADOUTS_GETLOADOUTARRAY_FN TAG_fnc_getLoadoutArray  // Custom loadout resolution function to use in the loadout system. REQUIRES MISSION SUPPORT.
 
 // Curator settings
 //#define XPT_DEFINE_CURATOR_CUSTOMLOADOUTS 1		// 0 = Disabled, 1 = Enabled.

--- a/description.ext
+++ b/description.ext
@@ -32,8 +32,8 @@ class Header
 
 //#define XPT_DEBUGMODE 0							// 0 = Disabled, 1 = Enabled.
 
-//#define XPT_DEFINE_CUSTOMLOADOUTS 1				                     // 0 = Disabled, 1 = Enabled. Enables the loadout system
-//#define XPT_CUSTOMLOADOUTS_LOADOUTOVERRIDE_FN TAG_fnc_getLoadoutArray  // Custom loadout resolution function to use in the loadout system. REQUIRES MISSION SUPPORT.
+//#define XPT_DEFINE_CUSTOMLOADOUTS 1				                      // 0 = Disabled, 1 = Enabled. Enables the loadout system
+//#define XPT_CUSTOMLOADOUTS_LOADOUTOVERRIDE_FN "TAG_fnc_getLoadoutArray" // Custom loadout resolution function to use in the loadout system. REQUIRES MISSION SUPPORT.
 
 // Curator settings
 //#define XPT_DEFINE_CURATOR_CUSTOMLOADOUTS 1		// 0 = Disabled, 1 = Enabled.

--- a/template/config/CfgFunctions.hpp
+++ b/template/config/CfgFunctions.hpp
@@ -42,6 +42,7 @@ class XPT
 	class loadout
 	{
 		file = "template\functions\loadout";
+		class getLoadoutArray {};				// Resolves loadout array for loadInventory
 		class exportInventory {};				// Exports a unit's inventory to the XPTLoadouts config format
 		class loadCurrentInventory {};			// Uses loadInventory to apply a loadout to a unit
 		class loadInventory {};					// Function for loading a unit's inventory

--- a/template/config/XPT_Defines.hpp
+++ b/template/config/XPT_Defines.hpp
@@ -48,11 +48,11 @@ XPT_safeStart = XPT_DEFINE_SAFESTART;
 #endif
 XPT_customLoadouts = XPT_DEFINE_CUSTOMLOADOUTS;
 
-// Custom loadouts resolve function. Defaults to XPT_fnc_resolveInventory
-#ifndef XPT_CUSTOMLOADOUTS_GETLOADOUTARRAY_FN
-	#define XPT_CUSTOMLOADOUTS_GETLOADOUTARRAY_FN XPT_fnc_getLoadoutArray
+// Custom loadouts override function. Defaults to XPT_fnc_getLoadoutArray
+#ifndef XPT_CUSTOMLOADOUTS_LOADOUTOVERRIDE_FN
+	#define XPT_CUSTOMLOADOUTS_LOADOUTOVERRIDE_FN "XPT_fnc_getLoadoutArray"
 #endif
-XPT_customLoadouts_getLoadoutArrayFunction = XPT_CUSTOMLOADOUTS_GETLOADOUTARRAY_FN;
+XPT_customLoadouts_loadoutOverrideFunction = XPT_CUSTOMLOADOUTS_LOADOUTOVERRIDE_FN;
 
 // Custom loadouts for zeus-spawned units. Defaults to disabled.
 #ifndef XPT_DEFINE_CURATOR_CUSTOMLOADOUTS

--- a/template/config/XPT_Defines.hpp
+++ b/template/config/XPT_Defines.hpp
@@ -48,6 +48,12 @@ XPT_safeStart = XPT_DEFINE_SAFESTART;
 #endif
 XPT_customLoadouts = XPT_DEFINE_CUSTOMLOADOUTS;
 
+// Custom loadouts resolve function. Defaults to XPT_fnc_resolveInventory
+#ifndef XPT_CUSTOMLOADOUTS_GETLOADOUTARRAY_FN
+	#define XPT_CUSTOMLOADOUTS_GETLOADOUTARRAY_FN XPT_fnc_getLoadoutArray
+#endif
+XPT_customLoadouts_getLoadoutArrayFunction = XPT_CUSTOMLOADOUTS_GETLOADOUTARRAY_FN;
+
 // Custom loadouts for zeus-spawned units. Defaults to disabled.
 #ifndef XPT_DEFINE_CURATOR_CUSTOMLOADOUTS
 	#define XPT_DEFINE_CURATOR_CUSTOMLOADOUTS 0

--- a/template/functions/loadout/fn_getLoadoutArray.sqf
+++ b/template/functions/loadout/fn_getLoadoutArray.sqf
@@ -1,0 +1,169 @@
+/*
+	XPT_fnc_getLoadoutArray
+	Author: Superxpdude, erem2k
+
+	Resolves loadout array for a unit from a config file
+    Used by default in XPT_fnc_loadInventory
+	
+	Config should be in the following format:
+	
+	class loadoutName
+	{
+		displayName = "Example Loadout"; // Currently unused, basically just a human-readable name for the loadout
+		
+		// Weapon definitions all use the following format:
+		// {Weapon Classname, Suppressor, Pointer (Laser/Flashlight), Optic, [Primary magazine, ammo count], [Secondary Magazine (GL), ammo count], Bipod}
+		// Any empty definitions must be defined as an empty string, or an empty array. Otherwise the loadout will not apply correctly.
+		
+		primaryWeapon[] = {"arifle_MXC_F", "", "acc_flashlight", "optic_ACO", ["30Rnd_65x39_caseless_mag",30], [], ""}; // Primary weapon definition
+		secondaryWeapon[] = {"launch_B_Titan_short_F", "", "", "", ["Titan_AP", 1], [], ""}; // Secondary weapon (Launcher) definition.
+		handgunWeapon[] = {"hgun_ACPC2_F", "", "", "", ["9Rnd_45ACP_Mag", 9], [], ""}; // Handgun definition
+		binocular = "Binocular";
+		
+		uniformClass = "U_B_CombatUniform_mcam_tshirt";
+		headgearClass = "H_Watchcap_blk";
+		facewearClass = "";
+		vestClass = "V_Chestrig_khk";
+		backpackClass = "B_AssaultPack_mcamo";
+		
+		// Linked items requires all six definitions to be present. Use empty strings if you do not want to add that item.
+		linkedItems[] = {"ItemMap", "ItemGPS", "ItemRadio", "ItemCompass", "ItemWatch", ""}; // Linked items for the unit, must follow the order of: Map, GPS, Radio, Compass, Watch, NVGs.
+		
+		uniformItems[] = {{"FirstAidKit", 3}, {"30Rnd_65x39_caseless_mag", 4}}; // Items to place in uniform. Includes weapon magazines
+		vestItems[] = {{"FirstAidKit", 3}, {"30Rnd_65x39_caseless_mag", 4}}; // Items to place in vest. Includes weapon magazines
+		backpackItems[] = {{"FirstAidKit", 3}, {"30Rnd_65x39_caseless_mag", 4}}; // Items to place in backpack. Includes weapon magazines
+		
+		basicMedUniform[] = {}; // Items to be placed in the uniform only when basic medical is being used
+		basicMedVest[] = {}; // Items to be placed in the vest only when basic medical is being used
+		basicMedBackpack[] = {}; // Items to be placed in the backpack only when basic medical is being used
+		
+		advMedUniform[] = {}; // Items to be placed in the uniform only when advanced medical is being used
+		advMedVest[] = {}; // Items to be placed in the vest only when advanced medical is being used
+		advMedBackpack[] = {}; // Items to be placed in the backpack only when advanced medical is being used
+	};
+	
+	Parameters:
+		0: Config - Loadout to apply.
+		
+	Returns: Loadout array
+        Compliant with setUnitLoadout array
+        https://community.bistudio.com/wiki/setUnitLoadout
+*/
+
+params [
+	["_baseClass", nil, [configNull]]
+];
+
+// Exit the script if _unit is not an object or _class is not a config class
+if ((isNil "_unit") or (isNil "_baseClass")) exitWith {[]};
+
+// Check if the specified class has sub-loadouts
+_subclasses = "true" configClasses _baseClass;
+if ((count _subclasses) > 0) then {
+	// If we have any subclasses, select a random one.
+	_class = selectRandom _subclasses;
+	_isSubclass = true;
+} else {
+	_class = _baseClass;
+};
+
+// Retrieve loadout data from config files
+private _displayName = [((_class >> "displayName") call BIS_fnc_getCfgData)] param [0, "", [""]];
+private _primaryWeapon = [((_class >> "primaryWeapon") call BIS_fnc_getCfgData)] param [0, [], [[]], [0,7]];
+private _secondaryWeapon = [((_class >> "secondaryWeapon") call BIS_fnc_getCfgData)] param [0, [], [[]], [0,7]];
+private _handgunWeapon = [((_class >> "handgunWeapon") call BIS_fnc_getCfgData)] param [0, [], [[]], [0,7]];
+private _binocular = [((_class >> "binocular") call BIS_fnc_getCfgData)] param [0, "", [""]];
+private _uniformClass = [((_class >> "uniformClass") call BIS_fnc_getCfgData)] param [0, "", ["",[]]];
+private _headgearClass = [((_class >> "headgearClass") call BIS_fnc_getCfgData)] param [0, "", ["",[]]];
+private _facewearClass = [((_class >> "facewearClass") call BIS_fnc_getCfgData)] param [0, "", ["",[]]];
+private _vestClass = [((_class >> "vestClass") call BIS_fnc_getCfgData)] param [0, "", ["",[]]];
+private _backpackClass = [((_class >> "backpackClass") call BIS_fnc_getCfgData)] param [0, "", ["",[]]];
+private _linkedItems = [((_class >> "linkedItems") call BIS_fnc_getCfgData)] param [0, [], [[]], 6];
+private _uniformItems = [((_class >> "uniformItems") call BIS_fnc_getCfgData)] param [0, [], [[]]];
+private _vestItems = [((_class >> "vestItems") call BIS_fnc_getCfgData)] param [0, [], [[]]];
+private _backpackItems = [((_class >> "backpackItems") call BIS_fnc_getCfgData)] param [0, [], [[]]];
+
+// Retrieve medical items from config file.
+if ((["xpt_medical_level", 0] call BIS_fnc_getParamValue) == 0) then {
+	// Only load these classes if basic medical is being used.
+	_uniformItems append ([((_class >> "basicMedUniform") call BIS_fnc_getCfgData)] param [0, [], [[]]]);
+	_vestItems append ([((_class >> "basicMedVest") call BIS_fnc_getCfgData)] param [0, [], [[]]]);
+	_backpackItems append ([((_class >> "basicMedBackpack") call BIS_fnc_getCfgData)] param [0, [], [[]]]);
+} else {
+	// Only load these classes if advanced medical is being used.
+	_uniformItems append ([((_class >> "advMedUniform") call BIS_fnc_getCfgData)] param [0, [], [[]]]);
+	_vestItems append ([((_class >> "advMedVest") call BIS_fnc_getCfgData)] param [0, [], [[]]]);
+	_backpackItems append ([((_class >> "advMedBackpack") call BIS_fnc_getCfgData)] param [0, [], [[]]]);
+};
+
+// Function to ensure that magazines have an ammo count defined
+private _fn_fixMagazine = {
+	private _x = _this;
+	// Only run if the item does not have a third entry in the array. Do not run if the item is a weapon.
+	if ((count _x == 2) AND {!((_x select 0) isEqualType [])}) then {
+		_classname = (_x select 0);
+		if (isClass (configFile >> "CfgMagazines" >> _classname)) then {
+			["warning", format ["Magazine type [%1] has no ammo count defined in loadout [%2].",_classname, configName _baseClass], "local"] call XPT_fnc_log;
+			_x set [2, (configFile >> "CfgMagazines" >> _classname >> "count") call BIS_fnc_getCfgData];
+		};
+	};
+	_x
+};
+
+_uniformItems = _uniformItems apply {_x call _fn_fixMagazine};
+_vestItems = _vestItems apply {_x call _fn_fixMagazine};
+_backpackItems = _backpackItems apply {_x call _fn_fixMagazine};
+
+// Equipment randomization support
+private _fn_equipmentSelect = {
+	private _return = if (_this isEqualType []) then {
+		selectRandom _this
+	} else {
+		_this
+	};
+	_return
+};
+
+_uniformClass = _uniformClass call _fn_equipmentSelect;
+_headgearClass = _headgearClass call _fn_equipmentSelect;
+_facewearClass = _facewearClass call _fn_equipmentSelect;
+_vestClass = _vestClass call _fn_equipmentSelect;
+_backpackClass = _backpackClass call _fn_equipmentSelect;
+
+// Merge some arrays into their main unit loadout entry
+private _uniformArray = [_uniformClass, _uniformItems];
+private _vestArray = [_vestClass, _vestItems];
+private _backpackArray = [_backpackClass, _backpackItems];
+private _binocularArray = [_binocular,"","","",[],[],""];
+
+// Check if the binoculars are a laser designator
+private _binocularMagazines = (configFile >> "CfgWeapons" >> _binocular >> "magazines") call BIS_fnc_getCfgDataArray;
+if ((count _binocularMagazines) > 0) then {
+	private _laserBattery = _binocularMagazines select 0;
+	private _batteryCount = (configFile >> "CfgMagazines" >> _laserBattery >> "count") call BIS_fnc_getCfgData;
+	_binocularArray set [4,[_laserBattery,_batteryCount]];
+};
+
+// Fix for "Bad Vehicle Type" errors regarding weapons and inventories
+{
+	// If the main classname is undefined, replace the array with an empty one.
+	if ((_x select 0) == "") then {
+		_x deleteRange [0,10]; // Ensure the entire array is emptied
+	};
+} forEach [_primaryWeapon, _secondaryWeapon, _handgunWeapon, _uniformArray, _vestArray, _backpackArray, _binocularArray];
+
+// Format and return our unit loadout array.
+private _loadout = [
+	_primaryWeapon,
+	_secondaryWeapon,
+	_handgunWeapon,
+	_uniformArray,
+	_vestArray,
+	_backpackArray,
+	_headgearClass, 
+	_facewearClass,
+	_binocularArray,
+	_linkedItems
+];
+
+_loadout;

--- a/template/functions/loadout/fn_getLoadoutArray.sqf
+++ b/template/functions/loadout/fn_getLoadoutArray.sqf
@@ -51,6 +51,7 @@
 */
 
 params [
+	["_unit", nil, [objNull]],
 	["_baseClass", nil, [configNull]]
 ];
 

--- a/template/functions/loadout/fn_loadInventory.sqf
+++ b/template/functions/loadout/fn_loadInventory.sqf
@@ -33,11 +33,11 @@ if (isNil "_baseClass") exitWith {
 };
 
 // Resolve loadout array, by default XPT_fnc_resolveInventory will be used
-private _getLoadoutFunctionName = getMissionConfigValue ["XPT_customLoadouts_loadoutOverrideFunction", "XPT_getLoadoutArray"];
-private _fnc_getLoadout = missionNamespace getVariable [_getLoadoutFunctionName, scriptNull];
+private _getLoadoutFunctionName = getMissionConfigValue ["XPT_customLoadouts_loadoutOverrideFunction", "XPT_fnc_getLoadoutArray"];
+private _fnc_getLoadout = missionNamespace getVariable [_getLoadoutFunctionName, nil];
 
 // Provided function does not exist
-if (isNull _fnc_getLoadout) then { 
+if (isNil "_fnc_getLoadout") then { 
 	["error", format["Provided getLoadoutArray function [%1] does not exist!", _getLoadoutFunctionName], 0] call XPT_fnc_log;
 	false;
 };
@@ -45,12 +45,16 @@ if (isNull _fnc_getLoadout) then {
 // Ensure that we've received what looks like loadout array
 private _loadout = [_unit, _baseClass] call _fnc_getLoadout;
 
-if ((isNil "_loadout") OR (typeName _loadout != "ARRAY")) exitWith {
-	["error", format["Received unexpected loadout type from [%1] call!", _getLoadoutFunctionName], 0] call XPT_fnc_log;
+if (isNil "_loadout") exitWith {
+	["error", format["Loadout [%1]: Did not receive loadout definition from [%2] call!", configName _baseClass, _getLoadoutFunctionName], 0] call XPT_fnc_log;
 	false;
 };
+if (typeName _loadout != "ARRAY") exitWith {
+	["error", format["Loadout [%1]: Received unexpected loadout type from [%2] call!", configName _baseClass, _getLoadoutFunctionName], 0] call XPT_fnc_log;
+	false;	
+};
 if (count(_loadout) < 10) exitWith {
-	["error", format["Received malformed loadout array from [%1] call!", _getLoadoutFunctionName], 0] call XPT_fnc_log;
+	["error", format["Loadout [%1]: Received malformed loadout array from [%2] call!", configName _baseClass, _getLoadoutFunctionName], 0] call XPT_fnc_log;
 	false;
 };
 

--- a/template/functions/loadout/fn_loadInventory.sqf
+++ b/template/functions/loadout/fn_loadInventory.sqf
@@ -1,44 +1,7 @@
 /*
 	XPT_fnc_loadInventory
 	Author: Superxpdude
-	Loads a custom inventory for a unit from a config file
-	
-	Config should be in the following format:
-	
-	class loadoutName
-	{
-		displayName = "Example Loadout"; // Currently unused, basically just a human-readable name for the loadout
-		
-		// Weapon definitions all use the following format:
-		// {Weapon Classname, Suppressor, Pointer (Laser/Flashlight), Optic, [Primary magazine, ammo count], [Secondary Magazine (GL), ammo count], Bipod}
-		// Any empty definitions must be defined as an empty string, or an empty array. Otherwise the loadout will not apply correctly.
-		
-		primaryWeapon[] = {"arifle_MXC_F", "", "acc_flashlight", "optic_ACO", ["30Rnd_65x39_caseless_mag",30], [], ""}; // Primary weapon definition
-		secondaryWeapon[] = {"launch_B_Titan_short_F", "", "", "", ["Titan_AP", 1], [], ""}; // Secondary weapon (Launcher) definition.
-		handgunWeapon[] = {"hgun_ACPC2_F", "", "", "", ["9Rnd_45ACP_Mag", 9], [], ""}; // Handgun definition
-		binocular = "Binocular";
-		
-		uniformClass = "U_B_CombatUniform_mcam_tshirt";
-		headgearClass = "H_Watchcap_blk";
-		facewearClass = "";
-		vestClass = "V_Chestrig_khk";
-		backpackClass = "B_AssaultPack_mcamo";
-		
-		// Linked items requires all six definitions to be present. Use empty strings if you do not want to add that item.
-		linkedItems[] = {"ItemMap", "ItemGPS", "ItemRadio", "ItemCompass", "ItemWatch", ""}; // Linked items for the unit, must follow the order of: Map, GPS, Radio, Compass, Watch, NVGs.
-		
-		uniformItems[] = {{"FirstAidKit", 3}, {"30Rnd_65x39_caseless_mag", 4}}; // Items to place in uniform. Includes weapon magazines
-		vestItems[] = {{"FirstAidKit", 3}, {"30Rnd_65x39_caseless_mag", 4}}; // Items to place in vest. Includes weapon magazines
-		backpackItems[] = {{"FirstAidKit", 3}, {"30Rnd_65x39_caseless_mag", 4}}; // Items to place in backpack. Includes weapon magazines
-		
-		basicMedUniform[] = {}; // Items to be placed in the uniform only when basic medical is being used
-		basicMedVest[] = {}; // Items to be placed in the vest only when basic medical is being used
-		basicMedBackpack[] = {}; // Items to be placed in the backpack only when basic medical is being used
-		
-		advMedUniform[] = {}; // Items to be placed in the uniform only when advanced medical is being used
-		advMedVest[] = {}; // Items to be placed in the vest only when advanced medical is being used
-		advMedBackpack[] = {}; // Items to be placed in the backpack only when advanced medical is being used
-	};
+	Loads a custom inventory for a unit from a config file or resolve function if one is provided in description.ext
 	
 	Parameters:
 		0: Object - Unit to apply loadout
@@ -75,114 +38,15 @@ if (!local _unit) exitWith {
 };
 */
 
-// Check if the specified class has sub-loadouts
-_subclasses = "true" configClasses _baseClass;
-if ((count _subclasses) > 0) then {
-	// If we have any subclasses, select a random one.
-	_class = selectRandom _subclasses;
-	_isSubclass = true;
-} else {
-	_class = _baseClass;
-};
+// Resolve loadout array, by default XPT_fnc_resolveInventory will be used
+// However, this can be overriden by the user by providing custom resolve function
+private _loadout = [_unit, _baseClass] call XPT_customLoadouts_getLoadoutArrayFunction;
 
-// Retrieve loadout data from config files
-private _displayName = [((_class >> "displayName") call BIS_fnc_getCfgData)] param [0, "", [""]];
-private _primaryWeapon = [((_class >> "primaryWeapon") call BIS_fnc_getCfgData)] param [0, [], [[]], [0,7]];
-private _secondaryWeapon = [((_class >> "secondaryWeapon") call BIS_fnc_getCfgData)] param [0, [], [[]], [0,7]];
-private _handgunWeapon = [((_class >> "handgunWeapon") call BIS_fnc_getCfgData)] param [0, [], [[]], [0,7]];
-private _binocular = [((_class >> "binocular") call BIS_fnc_getCfgData)] param [0, "", [""]];
-private _uniformClass = [((_class >> "uniformClass") call BIS_fnc_getCfgData)] param [0, "", ["",[]]];
-private _headgearClass = [((_class >> "headgearClass") call BIS_fnc_getCfgData)] param [0, "", ["",[]]];
-private _facewearClass = [((_class >> "facewearClass") call BIS_fnc_getCfgData)] param [0, "", ["",[]]];
-private _vestClass = [((_class >> "vestClass") call BIS_fnc_getCfgData)] param [0, "", ["",[]]];
-private _backpackClass = [((_class >> "backpackClass") call BIS_fnc_getCfgData)] param [0, "", ["",[]]];
-private _linkedItems = [((_class >> "linkedItems") call BIS_fnc_getCfgData)] param [0, [], [[]], 6];
-private _uniformItems = [((_class >> "uniformItems") call BIS_fnc_getCfgData)] param [0, [], [[]]];
-private _vestItems = [((_class >> "vestItems") call BIS_fnc_getCfgData)] param [0, [], [[]]];
-private _backpackItems = [((_class >> "backpackItems") call BIS_fnc_getCfgData)] param [0, [], [[]]];
+// Ensure that we've received loadout array
+if (isNil "_loadout" || typeName _loadout != "ARRAY") exitWith {false};
 
-// Retrieve medical items from config file.
-if ((["xpt_medical_level", 0] call BIS_fnc_getParamValue) == 0) then {
-	// Only load these classes if basic medical is being used.
-	_uniformItems append ([((_class >> "basicMedUniform") call BIS_fnc_getCfgData)] param [0, [], [[]]]);
-	_vestItems append ([((_class >> "basicMedVest") call BIS_fnc_getCfgData)] param [0, [], [[]]]);
-	_backpackItems append ([((_class >> "basicMedBackpack") call BIS_fnc_getCfgData)] param [0, [], [[]]]);
-} else {
-	// Only load these classes if advanced medical is being used.
-	_uniformItems append ([((_class >> "advMedUniform") call BIS_fnc_getCfgData)] param [0, [], [[]]]);
-	_vestItems append ([((_class >> "advMedVest") call BIS_fnc_getCfgData)] param [0, [], [[]]]);
-	_backpackItems append ([((_class >> "advMedBackpack") call BIS_fnc_getCfgData)] param [0, [], [[]]]);
-};
-
-// Function to ensure that magazines have an ammo count defined
-private _fn_fixMagazine = {
-	private _x = _this;
-	// Only run if the item does not have a third entry in the array. Do not run if the item is a weapon.
-	if ((count _x == 2) AND {!((_x select 0) isEqualType [])}) then {
-		_classname = (_x select 0);
-		if (isClass (configFile >> "CfgMagazines" >> _classname)) then {
-			["warning", format ["Magazine type [%1] has no ammo count defined in loadout [%2].",_classname,configName _baseClass], "local"] call XPT_fnc_log;
-			_x set [2, (configFile >> "CfgMagazines" >> _classname >> "count") call BIS_fnc_getCfgData];
-		};
-	};
-	_x
-};
-
-_uniformItems = _uniformItems apply {_x call _fn_fixMagazine};
-_vestItems = _vestItems apply {_x call _fn_fixMagazine};
-_backpackItems = _backpackItems apply {_x call _fn_fixMagazine};
-
-// Equipment randomization support
-private _fn_equipmentSelect = {
-	private _return = if (_this isEqualType []) then {
-		selectRandom _this
-	} else {
-		_this
-	};
-	_return
-};
-
-_uniformClass = _uniformClass call _fn_equipmentSelect;
-_headgearClass = _headgearClass call _fn_equipmentSelect;
-_facewearClass = _facewearClass call _fn_equipmentSelect;
-_vestClass = _vestClass call _fn_equipmentSelect;
-_backpackClass = _backpackClass call _fn_equipmentSelect;
-
-// Merge some arrays into their main unit loadout entry
-private _uniformArray = [_uniformClass, _uniformItems];
-private _vestArray = [_vestClass, _vestItems];
-private _backpackArray = [_backpackClass, _backpackItems];
-private _binocularArray = [_binocular,"","","",[],[],""];
-
-// Check if the binoculars are a laser designator
-private _binocularMagazines = (configFile >> "CfgWeapons" >> _binocular >> "magazines") call BIS_fnc_getCfgDataArray;
-if ((count _binocularMagazines) > 0) then {
-	private _laserBattery = _binocularMagazines select 0;
-	private _batteryCount = (configFile >> "CfgMagazines" >> _laserBattery >> "count") call BIS_fnc_getCfgData;
-	_binocularArray set [4,[_laserBattery,_batteryCount]];
-};
-
-// Fix for "Bad Vehicle Type" errors regarding weapons and inventories
-{
-	// If the main classname is undefined, replace the array with an empty one.
-	if ((_x select 0) == "") then {
-		_x deleteRange [0,10]; // Ensure the entire array is emptied
-	};
-} forEach [_primaryWeapon, _secondaryWeapon, _handgunWeapon, _uniformArray, _vestArray, _backpackArray, _binocularArray];
-
-// Start formatting our unit loadout array.
-private _loadout = [
-	_primaryWeapon,
-	_secondaryWeapon,
-	_handgunWeapon,
-	_uniformArray,
-	_vestArray,
-	_backpackArray,
-	_headgearClass, 
-	_facewearClass,
-	_binocularArray,
-	_linkedItems
-];
+// Should contain at least 10 entries for each loadout section
+if (count(_loadout) < 10) exitWith {false};
 
 // Apply the loadout
 _unit setUnitLoadout _loadout;


### PR DESCRIPTION
Addresses #57 

Summary:
* Moved loadout resolution section of `XPT_fnc_loadInventory` into separate function `XPT_fnc_getLoadoutArray` - it will be called by default if no loadout override function is provided by MM
* Added additional logging and checks in `XPT_fnc_loadInventory` around loadout array call
* Added optional `XPT_CUSTOMLOADOUTS_LOADOUTOVERRIDE_FN` parameter to description.ext

